### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
       - release
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     name: Build and Test


### PR DESCRIPTION
Potential fix for [https://github.com/guilhermescherer/ms-service-watch/security/code-scanning/1](https://github.com/guilhermescherer/ms-service-watch/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily involves reading repository contents and running tests, we will set `contents: read` as the minimal required permission. If additional permissions are needed (e.g., for pull requests or issues), they can be added explicitly. The `permissions` block will be added at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
